### PR TITLE
Poc: Prune Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+#local files
+.idea

--- a/lib/jsonapter.js
+++ b/lib/jsonapter.js
@@ -38,6 +38,21 @@ var prototype = {
             return value;
         }
     },
+    validatePruneValue:function(value){
+
+        if (_.isString(value) && _.isEmpty(value)) {
+            return "emptyString";
+        }
+        if(Array.isArray(value)){
+            if(value.length === 0) {
+                return "emptyArray";
+            }
+        }
+        if(_.isNaN(value)){
+            return "NaN";
+        }
+        return null;
+    },
     content: function (template, input) {
         var that = this;
         var content = template.content;
@@ -47,10 +62,21 @@ var prototype = {
             var contentValue = template.content[key];
             var value = that.evaluateValue(contentValue, input);
             if (value !== null) {
-                if (template.ignoreDeep) {
-                    r[key] = value;
-                } else {
-                    _.set(r, key, value);
+                if(!that.options.pruneValues || !Array.isArray(that.options.pruneValues)){
+                    if (template.ignoreDeep) {
+                        r[key] = value;
+                    } else {
+                        _.set(r, key, value);
+                    }
+                }else{
+                    var expr = that.validatePruneValue(value);
+                    if(!_.contains(that.options.pruneValues,expr) || (content[key]["default"] !== null && content[key]["default"] !== undefined)){
+                        if (template.ignoreDeep) {
+                            r[key] = value;
+                        } else {
+                            _.set(r, key, value);
+                        }
+                    }
                 }
                 hasValue = true;
             }
@@ -137,9 +163,7 @@ var prototype = {
     },
     evaluateExistsWhen: function (template, input) {
         var existsWhen = template.existsWhen;
-        if (!existsWhen) {
-            existsWhen = this.options.existsWhen;
-        }
+
         if (existsWhen) {
             if (Array.isArray(existsWhen)) {
                 return existsWhen.every(function (ew) {
@@ -153,9 +177,6 @@ var prototype = {
     },
     evaluateExistsUnless: function (template, input) {
         var existsUnless = template.existsUnless;
-        if (!existsUnless) {
-            existsUnless = this.options.existsUnless;
-        }
         if (existsUnless) {
             if (Array.isArray(existsUnless)) {
                 return existsUnless.every(function (ew) {

--- a/test/test-pruneValue.js
+++ b/test/test-pruneValue.js
@@ -1,0 +1,58 @@
+"use strict";
+
+var chai = require('chai');
+
+var json2json = require('../index');
+
+var caseEmptyValues = require('./test_cases/case-pruneValue.js');
+
+var expect = chai.expect;
+
+describe('pruneTest', function () {
+
+    it('Output should not contain emptyString,emptyArray and NaN values', function () {
+
+        var bbj2j = json2json;
+        var options;
+        options = {pruneValues: ["emptyString", "emptyArray", "NaN"]};
+        var j2j = bbj2j.instance(null, null, options);
+        var actual = j2j.run(caseEmptyValues.template, caseEmptyValues.input);
+        expect(actual).to.deep.equal(caseEmptyValues.expectedWithPruneOptions);
+    });
+
+    it('Output should contain emptyArray BUT Not emptyString and NaN', function () {
+
+        var bbj2j = json2json;
+        var options;
+        options = {pruneValues: ["emptyString", "NaN"]};
+        var j2j = bbj2j.instance(null, null, options);
+        var actual = j2j.run(caseEmptyValues.template, caseEmptyValues.input);
+        expect(actual).to.deep.equal(caseEmptyValues.expectedWithEmptyArrays);
+    });
+
+    it('Pass empty PruneValue Array. Output should be without expurgation of any values', function () {
+
+        var bbj2j = json2json;
+        var options = {pruneValues: []};
+        var j2j = bbj2j.instance(null, null, options);
+        var actual = j2j.run(caseEmptyValues.template, caseEmptyValues.input);
+        expect(actual).to.deep.equal(caseEmptyValues.expectedWithOutPruneOptions);
+    });
+
+    it('Dont pass pruneValues array. Output should be without expurgation of any values', function () {
+
+        var bbj2j = json2json;
+        var j2j = bbj2j.instance();
+        var actual = j2j.run(caseEmptyValues.template, caseEmptyValues.input);
+        expect(actual).to.deep.equal(caseEmptyValues.expectedWithOutPruneOptions);
+    });
+
+    it('Pass wrong values in pruneValues Array, Output should be without expurgation of any values', function () {
+
+        var bbj2j = json2json;
+        var options = {pruneValues: ["whatEver", 1]};
+        var j2j = bbj2j.instance(null, null, options);
+        var actual = j2j.run(caseEmptyValues.template, caseEmptyValues.input);
+        expect(actual).to.deep.equal(caseEmptyValues.expectedWithOutPruneOptions);
+    });
+});

--- a/test/test_cases/case-pruneValue.js
+++ b/test/test_cases/case-pruneValue.js
@@ -1,0 +1,335 @@
+"use strict";
+
+exports.input = {
+    a: {
+        b: {
+            c1: "i am key c1",
+            c2: "",
+            c3: undefined,
+            c4: [],
+            c5: NaN,
+            c6:true,
+            c7:false
+        },
+        d: NaN,
+        e: "value a.e",
+        f: [{
+            firstName: "sampleFirstName",
+            group: []
+        },
+            {
+                firstName: "sampleFirstName",
+                group: [1,3]
+            },
+            {
+                firstName: "sampleFirstName",
+                group: []
+            }],
+        g: {
+            firstName: "sampleLastName",
+            lastName: "",
+            age: NaN,
+            city: undefined,
+            Numbers:[]
+        },
+        h:{
+            firstName:"sampleFirstName",
+            lastName: "",
+            age: NaN,
+            city: undefined,
+            "h.a1":"I am Key with dot"
+        },
+        i:[{
+            showWeather:true,
+            weather:"sunny",
+            temperature:"70F",
+            city:"Dallas",
+            days:["mon","tue","wed"]
+        },
+            {
+                showWeather:true,
+                weather:"",
+                temperature:NaN,
+                city:undefined,
+                days:["thr","fri","sat"]
+            },
+            {
+                showWeather:true,
+                weather:"sunny",
+                temperature:"70F",
+                city:"Irving",
+                days:[]
+            },
+            {
+                showWeather:false,
+                weather:"sunny",
+                temperature:"70F",
+                city:"Ft.Worth",
+                days:[]
+            }]
+
+
+    }
+};
+
+var weatherTemplate = {
+    existsWhen:function(data){
+        return data.showWeather === true;
+    },
+    content: {
+        weather: {dataKey: "weather"},
+        temperature: {dataKey: "temperature"},
+        city: {dataKey: "city"},
+        days: {dataKey: "days"}
+    }
+};
+
+exports.template = {
+    content: {
+        dest_a1: {
+            dataKey: 'a.b.c1'
+        },
+        dest_a2: {
+            dataKey: 'a.b.c2'
+        },
+        dest_a3: {
+            dataKey: 'a.b.c3'
+        },
+        dest_a4: {
+            dataKey: 'a.b.c4'
+        },
+        dest_a5: {
+            dataKey: 'a.b.c5'
+        },
+        dest_a6: {
+            dataKey: 'a.b.c6'
+        },
+        dest_a7: {
+            dataKey: 'a.b.c7'
+        },
+        dest_b: {
+            content: {
+                dest_b0: {
+                    value: function (data) {
+                        return data.e;
+                    }
+                },
+                dest_b1: {
+                    dataKey: 'a.d',default:"I am Default for NaN"
+                }
+            },
+            dataKey: 'a'
+        },
+        dest_d:{dataKey:"a.d"},
+        dest_e:{dataKey:"a.e"},
+        dest_f: {
+            dataKey: "a.f",
+            content: {
+                firstName: {dataKey: "firstName"},
+                group: {dataKey: "group"}
+            }
+        },
+        dest_g:{
+            dataKey:"a.g",
+            content:{
+                firstName:{dataKey:"firstName"},
+                lastName: {dataKey:"lastName"},
+                age: {dataKey:"age"},
+                city: {dataKey:"city"},
+                Numbers:{dataKey:"numbers",default:"1"},
+                "dotValue":{dataKey:"h.a1"}
+            }
+        },
+        dest_h:{
+            ignoreDeep:true,
+            content:{
+                "dest.h1.firstName":{dataKey:"a.h.firstName"},
+                "dest.h2.lastName":{dataKey:"a.h.lastName"}
+            }
+        },
+        dest_i:{
+            arrayContent:[{
+                arrayContent :[ { dataKey:"a.i",value: weatherTemplate }],
+                default : []
+            }]
+        }
+
+    }
+};
+
+
+
+exports.expectedWithPruneOptions = {
+    "dest_a1": "i am key c1",
+    "dest_a6": true,
+    "dest_a7": false,
+    "dest_b": {
+        "dest_b0": "value a.e",
+        "dest_b1": "I am Default for NaN"
+    },
+    "dest_e": "value a.e",
+    "dest_f": [{
+        "firstName": "sampleFirstName"
+    },
+        {
+            "firstName": "sampleFirstName",
+            "group": [1,3]
+        },
+        {
+            "firstName": "sampleFirstName"
+        }],
+    "dest_g": {
+        "firstName": "sampleLastName",
+        "Numbers": "1"
+    },
+    "dest_h": {
+        "dest.h1.firstName": "sampleFirstName"
+    },
+    dest_i: [
+        {
+            "city": "Dallas",
+            "temperature": "70F",
+            "weather": "sunny",
+            "days": [
+                "mon",
+                "tue",
+                "wed"
+            ]
+        },
+        {
+            "days": [
+                "thr",
+                "fri",
+                "sat"
+            ]
+        },
+        {
+            "city": "Irving",
+            "temperature": "70F",
+            "weather": "sunny"
+        }
+    ]
+};
+
+exports.expectedWithOutPruneOptions = {
+    dest_a1: "i am key c1",
+    dest_a2: "",
+    dest_a4: [],
+    dest_a5: NaN,
+    dest_a6: true,
+    dest_a7: false,
+    dest_b: {
+        dest_b0: "value a.e",
+        dest_b1: "I am Default for NaN"
+    },
+    dest_d: NaN,
+    dest_e: "value a.e",
+    dest_f: [
+        {
+            firstName: "sampleFirstName",
+            group: []
+        },
+        {
+            firstName: "sampleFirstName",
+            group: [1,3 ]
+        },
+        {
+            firstName: "sampleFirstName",
+            group: []
+        }
+    ],
+    dest_g: {
+        Numbers: "1",
+        age: NaN,
+        firstName: "sampleLastName",
+        lastName: ""
+    },
+    dest_h: {
+        "dest.h1.firstName": "sampleFirstName",
+        "dest.h2.lastName": ""
+    },
+    "dest_i": [
+        {
+            "city": "Dallas",
+            "days": [
+                "mon",
+                "tue",
+                "wed"
+            ],
+            "temperature": "70F",
+            "weather": "sunny"
+        },
+        {
+            "days": [
+                "thr",
+                "fri",
+                "sat"
+            ],
+            "temperature": NaN,
+            "weather": ""
+        },
+        {
+            "city": "Irving",
+            "days": [],
+            "temperature": "70F",
+            "weather": "sunny"
+        }
+    ]
+};
+
+exports.expectedWithEmptyArrays = {
+    "dest_a1": "i am key c1",
+    "dest_a4": [],
+    "dest_a6": true,
+    "dest_a7": false,
+    "dest_b": {
+        "dest_b0": "value a.e",
+        "dest_b1": "I am Default for NaN"
+    },
+    "dest_e": "value a.e",
+    "dest_f": [{
+        "firstName": "sampleFirstName",
+        "group": []
+    },
+        {
+            "firstName": "sampleFirstName",
+            "group": [1,
+                3]
+        },
+        {
+            "firstName": "sampleFirstName",
+            "group": []
+        }],
+    "dest_g": {
+        "firstName": "sampleLastName",
+        "Numbers": "1"
+    },
+    "dest_h": {
+        "dest.h1.firstName": "sampleFirstName"
+    },
+    "dest_i": [
+        {
+            "city": "Dallas",
+            "temperature": "70F",
+            "weather": "sunny",
+            "days": [
+                "mon",
+                "tue",
+                "wed"
+            ]
+        },
+        {
+            "days": [
+                "thr",
+                "fri",
+                "sat"
+            ]
+        },
+        {
+            "city": "Irving",
+            "days": [],
+            "temperature": "70F",
+            "weather": "sunny"
+        }
+    ]
+};


### PR DESCRIPTION
To keep it simple-

Inside my options object. I am expecting pruneValues:["emptyArray","emptyString","NaN"], 

If client decides to pass a valid pruneValues Array ( either both values or any ), then all the keys with these values will not be present in the output. Client can always over write this rule using default rule.

This will help, those who already have bunch of templates and want to eliminate emptyArrays and emptyString keys from the JSON payload, without going back and start writing existsWhen rule.

Please review. 
Also, not sure why i am getting code modification from line 209 to 213. 
